### PR TITLE
Prevent omission of :files from raising KeyError

### DIFF
--- a/lib/fucking_shell_scripts/scp.rb
+++ b/lib/fucking_shell_scripts/scp.rb
@@ -17,7 +17,7 @@ module FuckingShellScripts
     private
 
     def create_local_archive
-      includes = @opts.fetch(:files) + @opts.fetch(:scripts)
+      includes = @opts.fetch(:files){ [] } + @opts.fetch(:scripts)
       `tar -czf #{FILENAME} #{includes.join(" ")}`
     end
 


### PR DESCRIPTION
Since `/files` is said to be optional in the documentation
