### PR TITLE
AWS VPC options and more

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ Completely confused by Chef?  Blowing your brains out over Ansible?  Lost contro
 ### Step 0: Install the gem
 
 ```Shell
-gem install fucking_shell_scripts
+gem build fucking_shell_scripts.gemspec
+gem install fucking_shell_scripts-0.99.gem
+
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Completely confused by Chef?  Blowing your brains out over Ansible?  Lost contro
 *   Wraps up the fog gem, so it can be used on any cloud service, including AWS, rackspace, etc.
 *   We've intentionally designed this tool to be insanely easy to use
 
-### Step 0: Install the gem
+### Step 0: Install the gem from source
 
 ```Shell
 gem build fucking_shell_scripts.gemspec

--- a/README.md
+++ b/README.md
@@ -124,6 +124,19 @@ environment variables, and will attempt to look up that environment
 variable. If FSS does not find that variable, an exception will be
 raised.
 
+#### AWS options
+
+- `vpc_id` _(String)_ - AWS VPC id where desired build has to be created
+
+- `subnet_id` _(String)_ - AWS VPC Subnet id where desired build has to be created
+
+- `vpn` _(Boolean)_ - Default is false. When set to true, uses private ip address to connect to the server
+
+- `key_name` _(String)_ - Use AWS keypair name
+
+- `private_key_path` _(String)_ - Location of private key on the local machine, You will have to provide this in order to ssh into the created machine
+
+
 ### Step 3: Add shell scripts that configure the server
 
 Seriously...just write shell scripts.

--- a/README.md
+++ b/README.md
@@ -108,8 +108,8 @@ availability_zone: us-east-1d
 key_name: global-key
 cloud:
   provider: AWS
-  aws_access_key_id: <=% ENV[AWS_ACCESS_KEY] %>
-  aws_secret_access_key: <%= ENV[AWS_SECRET_ACCESS_KEY] %>
+  aws_access_key_id: <=% ENV['AWS_ACCESS_KEY'] %>
+  aws_secret_access_key: <%= ENV['AWS_SECRET_ACCESS_KEY'] %>
   region: us-east-1
 
 ```

--- a/fucking_shell_scripts.gemspec
+++ b/fucking_shell_scripts.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "pry"
 
-  spec.add_dependency "fog", "~> 1.14.0"
+  spec.add_dependency "fog", "~> 1.22.0"
 end

--- a/lib/fucking_shell_scripts/cli.rb
+++ b/lib/fucking_shell_scripts/cli.rb
@@ -30,6 +30,16 @@ module FuckingShellScripts
 
     def options
       @options ||= FuckingShellScripts::Configuration.new(@opts).options
+
+      if @options.has_key? :ssh_ip_address
+        # pass
+      elsif @options.has_key? :vpn and @options.fetch(:vpn)
+        @options[:ssh_ip_address] = Proc.new {|server| server.private_ip_address }
+      else
+        @options[:ssh_ip_address] = Proc.new {|server| server.public_ip_address }
+      end
+
+      @options
     end
   end
 end

--- a/lib/fucking_shell_scripts/server.rb
+++ b/lib/fucking_shell_scripts/server.rb
@@ -24,6 +24,8 @@ module FuckingShellScripts
         ssh_ip_address: options.fetch(:ssh_ip_address),
       }
 
+      build_options[:username] = options.fetch(:ssh_username) if options.has_key? :ssh_username
+
       if options.has_key? :private_key_path
         build_options[:private_key_path] = options.fetch(:private_key_path)
       elsif options.has_key? :key_name
@@ -75,6 +77,7 @@ module FuckingShellScripts
       @server = connection.servers.get(instance_id)
       @server.private_key_path = options.fetch(:private_key_path)
       @server.ssh_ip_address = options.fetch(:ssh_ip_address)
+      @server.username = options.fetch(:ssh_username) if options.has_key? :ssh_username
       @server
     end
 

--- a/lib/fucking_shell_scripts/server.rb
+++ b/lib/fucking_shell_scripts/server.rb
@@ -15,14 +15,22 @@ module FuckingShellScripts
     end
 
     def build
-      @server = connection.servers.create(
+      build_options = {
         image_id: options.fetch(:image),
         flavor_id: options.fetch(:size),
         key_name: options.fetch(:key_name),
         tags: { "Name" => name },
         groups: options.fetch(:security_groups),
-        private_key_path: options.fetch(:private_key_path)
-      )
+      }
+
+      if options.has_key? :private_key_path
+        build_options[:private_key_path] = options.fetch(:private_key_path)
+      elsif options.has_key? :key_name
+        build_options[:key_name] = options.fetch(:key_name)
+      end
+
+      @server = connection.servers.create(build_options)
+
       print "Creating #{options.fetch(:size)} from #{options.fetch(:image)}"
 
       server.wait_for do

--- a/lib/fucking_shell_scripts/server.rb
+++ b/lib/fucking_shell_scripts/server.rb
@@ -20,7 +20,6 @@ module FuckingShellScripts
         flavor_id: options.fetch(:size),
         key_name: options.fetch(:key_name),
         tags: { "Name" => name },
-        groups: options.fetch(:security_groups),
         ssh_ip_address: options.fetch(:ssh_ip_address),
       }
 
@@ -30,6 +29,12 @@ module FuckingShellScripts
         build_options[:private_key_path] = options.fetch(:private_key_path)
       elsif options.has_key? :key_name
         build_options[:key_name] = options.fetch(:key_name)
+      end
+
+      if options.has_key? :security_group_ids
+        build_options[:security_group_ids] = options.fetch(:security_group_ids)
+      else
+        build_options[:groups] = options.fetch(:security_groups)
       end
 
       [:vpc_id, :subnet_id].each do |key|

--- a/lib/fucking_shell_scripts/server.rb
+++ b/lib/fucking_shell_scripts/server.rb
@@ -29,6 +29,12 @@ module FuckingShellScripts
         build_options[:key_name] = options.fetch(:key_name)
       end
 
+      [:vpc_id, :subnet_id].each do |key|
+        if options.has_key? key
+          build_options[key] = options.fetch(key)
+        end
+      end
+
       @server = connection.servers.create(build_options)
 
       print "Creating #{options.fetch(:size)} from #{options.fetch(:image)}"

--- a/lib/fucking_shell_scripts/server.rb
+++ b/lib/fucking_shell_scripts/server.rb
@@ -21,6 +21,7 @@ module FuckingShellScripts
         key_name: options.fetch(:key_name),
         tags: { "Name" => name },
         groups: options.fetch(:security_groups),
+        ssh_ip_address: options.fetch(:ssh_ip_address),
       }
 
       if options.has_key? :private_key_path
@@ -73,6 +74,7 @@ module FuckingShellScripts
       raise FuckingShellScripts::Server::MissingInstanceID , "Please specify the instance ID using the --instance-id option." if instance_id.nil?
       @server = connection.servers.get(instance_id)
       @server.private_key_path = options.fetch(:private_key_path)
+      @server.ssh_ip_address = options.fetch(:ssh_ip_address)
       @server
     end
 


### PR DESCRIPTION
- `vpc_id` _(String)_ - AWS VPC id where desired build has to be created
- `subnet_id` _(String)_ - AWS VPC Subnet id where desired build has to be created
- `vpn` _(Boolean)_ - Default is false. When set to true, uses private ip address to connect to the server
- `key_name` _(String)_ - Use AWS keypair name
- `private_key_path` _(String)_ - Location of private key on the local machine, You will have to provide this in order to ssh into the created machine
