### PR TITLE
Adding support for non-ubuntu usernames

### DIFF
--- a/lib/fucking_shell_scripts/server.rb
+++ b/lib/fucking_shell_scripts/server.rb
@@ -23,6 +23,7 @@ module FuckingShellScripts
         groups: options.fetch(:security_groups),
         private_key_path: options.fetch(:private_key_path)
       )
+      @server.username = options.fetch(:username) if options.fetch(:username)
       print "Creating #{options.fetch(:size)} from #{options.fetch(:image)}"
 
       server.wait_for do


### PR DESCRIPTION
Trying to use fucking shell scripts with a CentOS based AMI I found that the default username for a fog server instance is set to 'ubuntu'. This change lets you add a 'username: whatever' line to server definitions or default server definitions. 
