### PR TITLE
fix username being optional

### DIFF
--- a/lib/fucking_shell_scripts/server.rb
+++ b/lib/fucking_shell_scripts/server.rb
@@ -23,7 +23,7 @@ module FuckingShellScripts
         groups: options.fetch(:security_groups),
         private_key_path: options.fetch(:private_key_path)
       )
-      @server.username = options.fetch(:username) if options.fetch(:username)
+      @server.username = options.fetch(:username) if options[:username]
       print "Creating #{options.fetch(:size)} from #{options.fetch(:image)}"
 
       server.wait_for do


### PR DESCRIPTION
`Hash#fetch` throws an exception when the key doesn't exist, rather than returning nil.  The regular hash access method gives the proper result.
