### PR TITLE
Fetching username when only configuring

### DIFF
--- a/lib/fucking_shell_scripts/server.rb
+++ b/lib/fucking_shell_scripts/server.rb
@@ -60,6 +60,7 @@ module FuckingShellScripts
       raise FuckingShellScripts::Server::MissingInstanceID , "Please specify the instance ID using the --instance-id option." if instance_id.nil?
       @server = connection.servers.get(instance_id)
       @server.private_key_path = options.fetch(:private_key_path)
+      @server.username = options.fetch(:username) if options[:username]
       @server
     end
 


### PR DESCRIPTION
Right now, username different than ubuntu are not fetched when only configuring an already existing instance. This change corrects that.
