### PR TITLE
with support for EBS volumes

### DIFF
--- a/lib/fucking_shell_scripts/server.rb
+++ b/lib/fucking_shell_scripts/server.rb
@@ -23,7 +23,10 @@ module FuckingShellScripts
         groups:           options.fetch(:security_groups),
         private_key_path: options.fetch(:private_key_path)
       }
+
       create_server_options.merge!({subnet_id: options[:subnet]}) if options.has_key?(:subnet)
+      create_server_options.merge!({block_device_mapping: options[:block_device_mapping]}) if options.has_key?(:block_device_mapping)
+
       @server = connection.servers.create(create_server_options)
       @server.username = options.fetch(:username) if options[:username]
       $stdout.print "Creating #{options.fetch(:size)} from #{options.fetch(:image)}"

--- a/spec/fucking_shell_scripts/server_spec.rb
+++ b/spec/fucking_shell_scripts/server_spec.rb
@@ -13,7 +13,7 @@ module FuckingShellScripts
       let(:security_groups)   { 'some security_groups' }
       let(:private_key_path)  { 'some private_key_path' }
       let(:connection)        { double(Fog::Compute) }
-      let!(:time)              { Time.now }
+      let!(:time)             { Time.now }
 
       let(:options) do
         {
@@ -63,6 +63,25 @@ module FuckingShellScripts
           Server.new(connection, options).build
         end
       end
+
+      context 'when options include block_device_mapping' do
+        it 'creates a server with the passed in options including the block_device_mapping' do
+          block_device_mapping = {
+            block_device_mapping: [
+              {
+                'DeviceName'     => '/dev/sda1',
+                'Ebs.VolumeSize' => '20',
+                'Ebs.VolumeType' => 'gp2'
+              }
+            ]
+          }
+          options.merge!(block_device_mapping)
+          expect(servers).to receive(:create).with(hash_including(block_device_mapping)).and_return(server)
+
+          Server.new(connection, options).build
+        end
+      end
+
     end
   end
 end


### PR DESCRIPTION
Hi @brandonhilkert,

We have a need for changing the default size of EBS volumes.

This PR allows for adding multiple EBS volumes.

An EBS volume with `DeviceName` of `/dev/sda1` sets the configuration for the root disk.

If AOK, can you please merge and release it alongside the other changes?

Thanks

/cc @dueckes
